### PR TITLE
ci: enable manual dispatch + OIDC for post-deploy smoke workflow

### DIFF
--- a/.github/workflows/post_deploy_smoke.yml
+++ b/.github/workflows/post_deploy_smoke.yml
@@ -4,6 +4,8 @@ on:
   workflow_run:
     workflows: ["Deploy MedPlat (Local-First → Cloud Run)"]
     types: [completed]
+  # Allow manual runs for testing and debugging
+  workflow_dispatch:
 
 concurrency:
   group: smoke-post-deploy-${{ github.run_id }}
@@ -11,6 +13,8 @@ concurrency:
 
 permissions:
   contents: read
+  # Needed for Workload Identity auth steps that request OIDC tokens
+  id-token: write
 
 jobs:
   smoke:


### PR DESCRIPTION
Enable manual workflow_dispatch to allow quick test runs and grant id-token write permission so WIF auth can be used when manually dispatching. This is a small CI convenience change to verify the smoke checks in isolation.