### PR TITLE
fix: use prebuilt frontend/dist in Dockerfile so VITE_API_BASE is preserved

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,7 +8,13 @@ RUN npm install
 
 # Copy source and build
 COPY . .
-RUN npm run build
+# If a prebuilt `dist` directory exists (from the CI build step that baked
+# VITE_API_BASE into the static assets), use it. Otherwise run the build.
+RUN if [ -d "dist" ]; then \
+			echo "Using prebuilt dist/ (skip npm run build)"; \
+		else \
+			npm run build; \
+		fi
 
 # Cloud Run expects port 8080
 EXPOSE 8080


### PR DESCRIPTION
CI previously built the frontend and produced a verification artifact with VITE_API_BASE baked into dist. The Dockerfile ran a fresh npm run build during image build which ignored that baked value. This change skips the build when a prebuilt dist exists so the CI-built assets (with VITE_API_BASE) are preserved in the container image. This should make deployments reflect the backend URL correctly.

This PR updates  only.
