### PR TITLE
chore: set builds/use_kaniko to support --no-cache in frontend build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -178,6 +178,9 @@ jobs:
           TIMESTAMP=$(date +%s)
           IMAGE_TAG="europe-west1-docker.pkg.dev/$GCP_PROJECT/medplat/frontend:$TIMESTAMP"
           echo "Building image $IMAGE_TAG"
+          # Ensure Cloud Build uses Kaniko-based execution so --no-cache is supported
+          # (some projects have builds/use_kaniko=false by default). Set it idempotently.
+          gcloud config set builds/use_kaniko true || true
           # Force a fresh Cloud Build (no cached layers) to avoid stale assets
           # and ensure the image contains the most recent `dist/` contents.
           gcloud builds submit --no-cache --tag "$IMAGE_TAG" .


### PR DESCRIPTION
Set Cloud Build config property builds/use_kaniko to true before using --no-cache. This allows the frontend deploy step to use --no-cache safely. Small, idempotent change.