### PR TITLE
chore(frontend): add BUILD_DATE build-arg for cache-busting

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -183,7 +183,8 @@ jobs:
           gcloud config set builds/use_kaniko true || true
           # Force a fresh Cloud Build (no cached layers) to avoid stale assets
           # and ensure the image contains the most recent `dist/` contents.
-          gcloud builds submit --no-cache --tag "$IMAGE_TAG" .
+          # Pass the BUILD_DATE build-arg so Docker/kaniko caches change when TIMESTAMP changes.
+          gcloud builds submit --no-cache --substitutions=_BUILD_DATE="$TIMESTAMP" --tag "$IMAGE_TAG" .
           gcloud run deploy medplat-frontend \
             --image "$IMAGE_TAG" \
             --region europe-west1 \

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,6 +2,12 @@
 FROM node:18-alpine
 WORKDIR /app
 
+# Allow a build-time cache-buster so CI can force a fresh image without
+# relying only on Cloud Build flags. This ARG is harmless and written to a
+# file to ensure it affects the image layer when changed.
+ARG BUILD_DATE=""
+RUN if [ -n "$BUILD_DATE" ]; then mkdir -p /buildmeta && echo "$BUILD_DATE" > /buildmeta/BUILD_DATE || true; fi
+
 # Install deps
 COPY package*.json ./
 RUN npm install


### PR DESCRIPTION
Add a harmless  to  and pass a timestamp from CI so builds vary when a timestamp changes. This gives an explicit cache-bust mechanism (in addition to --no-cache) and is idempotent and safe.

Files changed:
- frontend/Dockerfile: adds ARG BUILD_DATE and writes it into /buildmeta/BUILD_DATE
- .github/workflows/deploy.yml: pass the TIMESTAMP as _BUILD_DATE substitution to Cloud Build

This is low-risk; it helps ensure Cloud Run receives freshly-built frontend assets.
