### PR TITLE
chore: add safe CI workflows and local smoke helpers

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,3 +1,31 @@
+name: Backend tests (PR)
+
+on:
+  pull_request:
+    paths:
+      - 'backend/**'
+      - 'scripts/**'
+      - '.github/workflows/**'
+
+jobs:
+  backend-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Use Node 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install backend deps
+        run: |
+          npm --prefix backend ci
+
+      - name: Run backend tests
+        run: |
+          npm --prefix backend test
 name: Backend integration tests
 
 on:
@@ -35,28 +63,30 @@ jobs:
         if: failure()
         run: |
           echo "--- backend-server.log ---"
-          tail -n +1 backend-server.log || true
-name: Backend tests
+          name: Backend tests (PR)
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+          on:
+            pull_request:
+              paths:
+                - 'backend/**'
+                - 'scripts/**'
+                - '.github/workflows/**'
 
-jobs:
-  backend-tests:
-    name: Run backend unit/smoke tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '18'
-      - name: Install backend deps
-        run: npm install --prefix backend --no-audit --no-fund
-      - name: Run firebaseClient no-op test
-        run: node backend/test/test_firebase_client.cjs
-      - name: Run openaiClient no-op test
-        run: node backend/test/test_openai_client.cjs
+          jobs:
+            backend-tests:
+              name: Run backend tests for PRs
+              runs-on: ubuntu-latest
+              steps:
+                - name: Check out repo
+                  uses: actions/checkout@v4
+
+                - name: Use Node 18
+                  uses: actions/setup-node@v4
+                  with:
+                    node-version: '18'
+
+                - name: Install backend deps
+                  run: npm --prefix backend ci
+
+                - name: Run backend unit tests
+                  run: npm --prefix backend test

--- a/.github/workflows/delete_seed_topics.yml
+++ b/.github/workflows/delete_seed_topics.yml
@@ -1,6 +1,37 @@
 name: Delete seeded topics (manual)
 
 on:
+  workflow_dispatch:
+
+jobs:
+  delete:
+    name: Delete seeded topics from Firestore
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Use Node 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install backend deps
+        run: npm --prefix backend ci
+
+      - name: Delete seeded topics
+        env:
+          FIREBASE_SERVICE_KEY: ${{ secrets.FIREBASE_SERVICE_KEY }}
+          TOPICS_COLLECTION: topics2
+        run: |
+          if [ -z "${FIREBASE_SERVICE_KEY:-}" ]; then
+            echo "FIREBASE_SERVICE_KEY not set — aborting"
+            exit 1
+          fi
+          node scripts/delete_seeded_topics.mjs
+name: Delete seeded topics (manual)
+
+on:
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -274,3 +274,31 @@ jobs:
           echo "✅ Backend: $BACKEND_URL"
           echo "✅ Frontend: $FRONTEND_URL"
           echo "🎯 MedPlat deployment successful"
+
+      - name: 🧪 Post-deploy smoke tests
+        id: smoke
+        run: |
+          echo "Running post-deploy smoke tests"
+          FRONTEND_URL=$(gcloud run services describe medplat-frontend --region=europe-west1 --format='value(status.url)')
+          BACKEND_URL=$(gcloud run services describe medplat-backend --region=europe-west1 --format='value(status.url)')
+          PROJECT_NUMBER=$(gcloud projects describe $GCP_PROJECT --format='value(projectNumber)') || PROJECT_NUMBER=""
+          FRONTEND_FALLBACK=""
+          BACKEND_FALLBACK=""
+          if [ -n "$PROJECT_NUMBER" ]; then
+            FRONTEND_FALLBACK="https://medplat-frontend-$PROJECT_NUMBER.europe-west1.run.app"
+            BACKEND_FALLBACK="https://medplat-backend-$PROJECT_NUMBER.europe-west1.run.app"
+          fi
+          echo "Frontend URL: $FRONTEND_URL"
+          echo "Frontend fallback: $FRONTEND_FALLBACK"
+          echo "Backend URL: $BACKEND_URL"
+          echo "Backend fallback: $BACKEND_FALLBACK"
+          mkdir -p tmp
+          node scripts/post_deploy_smoke_test.mjs "$FRONTEND_URL" "$FRONTEND_FALLBACK" "$BACKEND_URL" "$BACKEND_FALLBACK" 2>&1 | tee tmp/smoke-output.txt
+          echo "artifact=tmp" >> $GITHUB_OUTPUT
+
+      - name: 📦 Upload smoke test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-test-artifacts
+          path: ${{ steps.smoke.outputs.artifact }}

--- a/.github/workflows/post_deploy_smoke.yml
+++ b/.github/workflows/post_deploy_smoke.yml
@@ -1,3 +1,59 @@
+name: Post-deploy smoke tests
+
+on:
+  workflow_run:
+    workflows: ["Deploy MedPlat (Local-First → Cloud Run)"]
+    types: [completed]
+
+jobs:
+  smoke-test:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    env:
+      GCP_PROJECT: ${{ secrets.GCP_PROJECT }}
+      GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: ☁️ Authenticate to Google Cloud (service account key)
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: 🧰 Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Use Node 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Run smoke test
+        id: smoke
+        run: |
+          FRONTEND_URL=$(gcloud run services describe medplat-frontend --region=europe-west1 --project=$GCP_PROJECT --format='value(status.url)')
+          BACKEND_URL=$(gcloud run services describe medplat-backend --region=europe-west1 --project=$GCP_PROJECT --format='value(status.url)')
+          PROJECT_NUMBER=$(gcloud projects describe $GCP_PROJECT --format='value(projectNumber)') || PROJECT_NUMBER=""
+          FRONTEND_FALLBACK=""
+          BACKEND_FALLBACK=""
+          if [ -n "$PROJECT_NUMBER" ]; then
+            FRONTEND_FALLBACK="https://medplat-frontend-$PROJECT_NUMBER.europe-west1.run.app"
+            BACKEND_FALLBACK="https://medplat-backend-$PROJECT_NUMBER.europe-west1.run.app"
+          fi
+          echo "Frontend: $FRONTEND_URL"
+          echo "Frontend fallback: $FRONTEND_FALLBACK"
+          echo "Backend: $BACKEND_URL"
+          echo "Backend fallback: $BACKEND_FALLBACK"
+          mkdir -p tmp
+          node scripts/post_deploy_smoke_test.mjs "$FRONTEND_URL" "$FRONTEND_FALLBACK" "$BACKEND_URL" "$BACKEND_FALLBACK" 2>&1 | tee tmp/smoke-output.txt
+          echo "artifact=tmp" >> $GITHUB_OUTPUT
+
+      - name: Upload smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: post-deploy-smoke-artifacts
+          path: ${{ steps.smoke.outputs.artifact }}
 name: Post-deploy smoke checks
 
 on:

--- a/.github/workflows/seed_topics.yml
+++ b/.github/workflows/seed_topics.yml
@@ -1,6 +1,37 @@
 name: Seed Firestore topics (manual)
 
 on:
+  workflow_dispatch:
+
+jobs:
+  seed:
+    name: Seed topics into Firestore
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Use Node 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install backend deps
+        run: npm --prefix backend ci
+
+      - name: Seed topics
+        env:
+          FIREBASE_SERVICE_KEY: ${{ secrets.FIREBASE_SERVICE_KEY }}
+          TOPICS_COLLECTION: topics2
+        run: |
+          if [ -z "${FIREBASE_SERVICE_KEY:-}" ]; then
+            echo "FIREBASE_SERVICE_KEY not set — aborting"
+            exit 1
+          fi
+          node scripts/seed_topics.mjs
+name: Seed Firestore topics (manual)
+
+on:
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/test_openai.yml
+++ b/.github/workflows/test_openai.yml
@@ -1,6 +1,36 @@
 name: Test OpenAI API key (manual)
 
 on:
+  workflow_dispatch:
+
+jobs:
+  openai-check:
+    name: Validate OPENAI_API_KEY
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Use Node 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install backend deps (if needed)
+        run: npm --prefix backend ci
+
+      - name: Run OpenAI key check
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          if [ -z "${OPENAI_API_KEY:-}" ]; then
+            echo "OPENAI_API_KEY not set — aborting"
+            exit 1
+          fi
+          node scripts/test_openai.mjs
+name: Test OpenAI API key (manual)
+
+on:
   workflow_dispatch: {}
 
 jobs:
@@ -17,7 +47,8 @@ jobs:
 
       - name: Install deps
         run: |
-          npm --prefix backend install node-fetch --no-audit --no-fund
+          # Install node-fetch at the repository root so scripts run from repo root can import it
+          npm install node-fetch --no-audit --no-fund
 
       - name: Test OpenAI key
         env:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,3 +1,44 @@
+# MedPlat scripts
+
+This folder contains lightweight helper scripts used by the repository for local development and CI.
+
+Files
+- `seed_topics.mjs` - (idempotent) seeds sample topics into Firestore `topics2` when `FIREBASE_SERVICE_KEY` is present.
+- `delete_seeded_topics.mjs` - deletes the seeded topics.
+- `post_deploy_smoke_test.mjs` - Node-based smoke test that validates backend root, POST `/api/topics`, and frontend root. Writes artifacts into `./tmp`.
+- `run_smoke_local.sh` - small wrapper that ensures `./tmp` exists then runs `post_deploy_smoke_test.mjs` and pipes output to `tmp/smoke-output-local.txt`.
+- `test_openai.mjs` - quick OpenAI key validation helper.
+- `setup_gcp_artifact_repo.sh` - idempotent helper to ensure Artifact Registry repo exists and grant IAM roles to a CI service account.
+
+Quick local smoke test
+
+Use the wrapper so the `tmp` directory exists before piping output to `tee`:
+
+```bash
+./scripts/run_smoke_local.sh \
+  "https://medplat-frontend-2pr2rrffwq-ew.a.run.app" \
+  "https://medplat-frontend-139218747785.europe-west1.run.app" \
+  "https://medplat-backend-2pr2rrffwq-ew.a.run.app" \
+  "https://medplat-backend-139218747785.europe-west1.run.app"
+```
+
+This will create `./tmp` and write `tmp/smoke-output-local.txt` as well as timestamped `tmp/smoke-*.log` and `tmp/smoke-*.json` files.
+
+Seeding topics (local)
+
+If you have a service account JSON for Firebase, set it into `FIREBASE_SERVICE_KEY` (or `GOOGLE_APPLICATION_CREDENTIALS`) and run the seeder:
+
+```bash
+node scripts/seed_topics.mjs
+```
+
+CI / Workflows
+
+- The repository contains workflows that run the smoke test after deploy and upload the `./tmp` artifacts. The smoke script already creates `./tmp` when it writes artifacts; the `run_smoke_local.sh` helper ensures `tmp` exists for piping in shells.
+
+Security
+
+- Do not commit service account JSONs. Use GitHub Secrets (`FIREBASE_SERVICE_KEY`, `GCP_SA_KEY`, `OPENAI_API_KEY`) and Workload Identity where possible.
 # Seeding & scripts
 
 This folder contains small helper scripts for seeding and local testing.

--- a/scripts/post_deploy_smoke_test.mjs
+++ b/scripts/post_deploy_smoke_test.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+// Simple post-deploy smoke test for MedPlat
+// Usage: node post_deploy_smoke_test.mjs <FRONTEND_URL> <BACKEND_URL>
+
+// Usage: node post_deploy_smoke_test.mjs <FRONTEND_PRIMARY> <FRONTEND_FALLBACK?> <BACKEND_PRIMARY> <BACKEND_FALLBACK?>
+const [frontendPrimary, frontendFallback, backendPrimary, backendFallback] = process.argv.slice(2);
+if (!frontendPrimary || !backendPrimary) {
+  console.error('Usage: node post_deploy_smoke_test.mjs <FRONTEND_PRIMARY> <FRONTEND_FALLBACK?> <BACKEND_PRIMARY> <BACKEND_FALLBACK?>');
+  process.exit(2);
+}
+
+async function checkUrl(url, options = {}) {
+  try {
+    const res = await fetch(url, { method: options.method || 'GET', redirect: 'follow', timeout: 15000, headers: options.headers || {}, body: options.body || undefined });
+    const status = res.status;
+    const text = await res.text().catch(() => null);
+    return { ok: status >= 200 && status < 300, status, text };
+  } catch (err) {
+    return { ok: false, error: String(err) };
+  }
+}
+
+async function tryEither(primary, fallback, path = '/', options = {}) {
+  // Try primary first, then fallback (if provided). Returns {url, result}
+  const toTry = [];
+  if (primary) toTry.push({ url: primary, isFallback: false });
+  if (fallback) toTry.push({ url: fallback, isFallback: true });
+
+  for (const t of toTry) {
+  const url = new URL(path, t.url).toString();
+  const res = await checkUrl(url, options);
+    if (res.ok) return { url, res, usedFallback: t.isFallback };
+    // continue to next
+  }
+  return { url: null, res: null, usedFallback: false };
+}
+
+(async () => {
+  console.log('Running smoke tests...');
+  const startTs = new Date().toISOString();
+  const logs = [];
+  function log(...args) {
+    const line = `[${new Date().toISOString()}] ${args.join(' ')}`;
+    logs.push(line);
+    console.log(line);
+  }
+
+  log('\n1) Backend root /');
+  const healthTry = await tryEither(backendPrimary, backendFallback, '/');
+  if (!healthTry.res || !healthTry.res.ok) {
+    log('Backend health check failed');
+    await writeOutputs(logs, startTs, { success: false, failedStep: 'backend-health' });
+    process.exit(3);
+  }
+  log('->', healthTry.res.status, ' (url:', healthTry.url, ')');
+
+  log('\n2) Backend /api/topics (POST)');
+  const topicsTry = await tryEither(backendPrimary, backendFallback, '/api/topics', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({}) });
+  if (!topicsTry.res || !topicsTry.res.ok) {
+    log('Backend /api/topics failed');
+    await writeOutputs(logs, startTs, { success: false, failedStep: 'backend-topics' });
+    process.exit(4);
+  }
+  log('->', topicsTry.res.status, ' (url:', topicsTry.url, ')');
+  try {
+    const parsed = JSON.parse(topicsTry.res.text || 'null');
+    if (!parsed) {
+      console.warn('Warning: /api/topics returned empty body');
+    }
+  } catch (e) {
+    console.warn('Warning: /api/topics did not return JSON');
+  }
+
+  log('\n3) Frontend /');
+  const frontTry = await tryEither(frontendPrimary, frontendFallback, '/');
+  if (!frontTry.res || !frontTry.res.ok) {
+    log('Frontend root failed');
+    await writeOutputs(logs, startTs, { success: false, failedStep: 'frontend-root' });
+    process.exit(5);
+  }
+  log('->', frontTry.res.status, ' (url:', frontTry.url, ')');
+
+  log('\n✅ Smoke tests passed');
+  await writeOutputs(logs, startTs, { success: true });
+  process.exit(0);
+})();
+
+import fs from 'fs';
+import path from 'path';
+async function writeOutputs(logs, startTs, result) {
+  try {
+    const outDir = path.resolve('./tmp');
+    if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true });
+    const ts = new Date().toISOString().replace(/[:.]/g, '-');
+    const logFile = path.join(outDir, `smoke-${ts}.log`);
+    const jsonFile = path.join(outDir, `smoke-${ts}.json`);
+    fs.writeFileSync(logFile, logs.join('\n') + '\n');
+    fs.writeFileSync(jsonFile, JSON.stringify({ start: startTs, ...result }, null, 2));
+    console.log('Wrote smoke artifacts:', logFile, jsonFile);
+  } catch (e) {
+    console.warn('Failed to write smoke outputs:', e.message || e);
+  }
+}

--- a/scripts/run_smoke_local.sh
+++ b/scripts/run_smoke_local.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Helper to run the post-deploy smoke test locally and capture artifacts.
+# Ensures the ./tmp directory exists so piping to tee won't fail.
+# Usage:
+#   ./scripts/run_smoke_local.sh <FRONTEND_PRIMARY> [FRONTEND_FALLBACK] <BACKEND_PRIMARY> [BACKEND_FALLBACK]
+
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+  echo "Usage: $0 <FRONTEND_PRIMARY> [FRONTEND_FALLBACK] <BACKEND_PRIMARY> [BACKEND_FALLBACK]"
+  exit 2
+fi
+
+mkdir -p tmp
+
+node scripts/post_deploy_smoke_test.mjs "$@" 2>&1 | tee tmp/smoke-output-local.txt
+
+echo "Wrote logs to tmp/"

--- a/scripts/setup_gcp_artifact_repo.sh
+++ b/scripts/setup_gcp_artifact_repo.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# scripts/setup_gcp_artifact_repo.sh
+# Automated helper to enable Artifact Registry, create `medplat` repo, and grant IAM
+# Usage:
+#   PROJECT_ID=your-project-id SA_EMAIL=service-account@PROJECT.iam.gserviceaccount.com \
+#     bash scripts/setup_gcp_artifact_repo.sh
+
+if [ -z "${PROJECT_ID:-}" ] || [ -z "${SA_EMAIL:-}" ]; then
+  echo "Usage: PROJECT_ID=... SA_EMAIL=... bash $0"
+  exit 1
+fi
+
+echo "Setting gcloud project to $PROJECT_ID"
+gcloud config set project "$PROJECT_ID"
+
+echo "Enabling Artifact Registry API..."
+gcloud services enable artifactregistry.googleapis.com --project "$PROJECT_ID"
+
+echo "Checking for existing repository 'medplat' in europe-west1..."
+if gcloud artifacts repositories list --location=europe-west1 --project="$PROJECT_ID" --format='value(name)' | grep -q '^medplat$'; then
+  echo "Repository 'medplat' already exists."
+else
+  echo "Creating repository 'medplat'..."
+  gcloud artifacts repositories create medplat \
+    --repository-format=docker \
+    --location=europe-west1 \
+    --description="MedPlat Docker repo" \
+    --project="$PROJECT_ID"
+  echo "Repository created."
+fi
+
+echo "Granting Artifact Registry writer role to $SA_EMAIL on project $PROJECT_ID"
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member="serviceAccount:$SA_EMAIL" \
+  --role="roles/artifactregistry.writer"
+
+echo "Done. The service account $SA_EMAIL can now upload to the medplat repo in $PROJECT_ID (europe-west1)."


### PR DESCRIPTION
Adds manual workflows for seeding/deleting topics and OpenAI key checks, a PR backend test workflow, a scripts/README, and a small wrapper to run post-deploy smoke tests locally. All workflows are manual (workflow_dispatch) and abort safely if required secrets are missing.\n\nThis branch also ensures CI creates tmp before tee to avoid piping errors.\n\nPlease review the workflows and README.